### PR TITLE
fix: OnLocalTimeZoneChanged method

### DIFF
--- a/src/BlazorLocalTime/Components/LocalTimeForm.razor.cs
+++ b/src/BlazorLocalTime/Components/LocalTimeForm.razor.cs
@@ -43,17 +43,16 @@ public sealed partial class LocalTimeForm<T> : ComponentBase, IDisposable
 
     private async void OnLocalTimeZoneChangedDetailed(object? sender, TimeZoneChangedEventArgs e)
     {
-        var prevTimeZone = e.PreviousTimeZone ?? LocalTimeService.BrowserTimeZoneInfo;
-        var currTimeZone = e.CurrentTimeZone ?? LocalTimeService.BrowserTimeZoneInfo;
+        var prevTimeZone = e.PreviousTimeZone;
+        var currTimeZone = e.CurrentTimeZone;
         if (currTimeZone == null)
         {
-            // If current timezone is null, we cannot proceed with the conversion.
-            // This can happen if the browser failed time zone detection.
+            // If current timezone is null, this can happen if the browser failed time zone detection.
             return;
         }
         if (prevTimeZone == null)
         {
-            // timezone is available now
+            // timezone is available now !
             await InvokeAsync(StateHasChanged);
             return;
         }


### PR DESCRIPTION
This pull request includes a minor update to the `Dispose` method in `LocalTimeForm.razor.cs`, simplifying the handling of time zone information and improving clarity in comments.

Key changes:

* Simplified variable assignments by removing fallback to `LocalTimeService.BrowserTimeZoneInfo` when time zone information is null. (`[src/BlazorLocalTime/Components/LocalTimeForm.razor.csL46-R55](diffhunk://#diff-90cb449b6c48dae0f5b59260cdaa3eacc778bae8a92731a60f707cb7ec19e77cL46-R55)`)
* Improved comment clarity by removing redundant explanations and adding emphasis where appropriate. (`[src/BlazorLocalTime/Components/LocalTimeForm.razor.csL46-R55](diffhunk://#diff-90cb449b6c48dae0f5b59260cdaa3eacc778bae8a92731a60f707cb7ec19e77cL46-R55)`)