### PR TITLE
Add semantic HTML time element support to LocalTimeText component

### DIFF
--- a/example/BlazorLocalTimeSample/Pages/Home.razor
+++ b/example/BlazorLocalTimeSample/Pages/Home.razor
@@ -53,8 +53,15 @@
 </code></pre>
 
 <h2>Using as a Component</h2>
-<p>To simply display a local time as text, use the <code>LocalTimeText</code> component:</p>
+<p>
+    To display a local time with semantic HTML, use the <code>LocalTimeText</code> component. By default, it wraps the output in an HTML <code>&lt;time&gt;</code> element with proper datetime attribute for accessibility.
+    If you need just the text without the <code>&lt;time&gt;</code> element wrapper, you can disable it using the <code>DisableTimeElement</code> parameter.
+</p>
+
 <pre><code class="language-razor">&lt;LocalTimeText Value="@@DateTime.UtcNow" Format="yyyy-MM-dd HH:mm:ssK" /&gt;
+&lt;!-- should output something like this: 
+&lt;time datetime="2025-06-30T17:45:27.4610000Z"&gt;2025-07-01 02:45:27+09:00&lt;/time&gt;  
+--&gt;
 </code></pre>
 
 <div class="component-sample">

--- a/src/BlazorLocalTime/Components/LocalTimeText.razor
+++ b/src/BlazorLocalTime/Components/LocalTimeText.razor
@@ -1,3 +1,10 @@
 ﻿@namespace BlazorLocalTime
 
-@FormattedValue
+@if (!DisableTimeElement)
+{
+    <time datetime="@IsoDateTime">@FormattedValue</time>
+}
+else
+{
+    @FormattedValue
+}

--- a/src/BlazorLocalTime/Components/LocalTimeText.razor.cs
+++ b/src/BlazorLocalTime/Components/LocalTimeText.razor.cs
@@ -25,6 +25,14 @@ public sealed partial class LocalTimeText : ComponentBase, IDisposable
     [Parameter]
     public string Format { get; set; } = "yyyy-MM-dd HH:mm:ss";
 
+    /// <summary>
+    /// Gets or sets whether to wrap the output in an HTML &lt;time&gt; element with a datetime attribute.
+    /// When false, generates a semantic &lt;time&gt; tag with ISO-8601 datetime attribute for accessibility.
+    /// The default value is false.
+    /// </summary>
+    [Parameter]
+    public bool DisableTimeElement { get; set; } = false;
+
     /// <inheritdoc />
     protected override void OnInitialized()
     {
@@ -47,4 +55,7 @@ public sealed partial class LocalTimeText : ComponentBase, IDisposable
         Value.HasValue && LocalTimeService.IsTimeZoneInfoAvailable
             ? LocalTimeService.ToLocalTimeOffset(Value.Value).ToString(Format)
             : null;
+
+    // ISO-8601 datetime attribute for the time element
+    private string? IsoDateTime => Value?.UtcDateTime.ToString("O");
 }

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
@@ -63,6 +63,8 @@ namespace BlazorLocalTime
     {
         public LocalTimeText() { }
         [Microsoft.AspNetCore.Components.Parameter]
+        public bool DisableTimeElement { get; set; }
+        [Microsoft.AspNetCore.Components.Parameter]
         public string Format { get; set; }
         [Microsoft.AspNetCore.Components.Parameter]
         public System.DateTimeOffset? Value { get; set; }

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
@@ -63,6 +63,8 @@ namespace BlazorLocalTime
     {
         public LocalTimeText() { }
         [Microsoft.AspNetCore.Components.Parameter]
+        public bool DisableTimeElement { get; set; }
+        [Microsoft.AspNetCore.Components.Parameter]
         public string Format { get; set; }
         [Microsoft.AspNetCore.Components.Parameter]
         public System.DateTimeOffset? Value { get; set; }

--- a/tests/BlazorLocalTimeTest/Component/LocalTimeTotal1.razor
+++ b/tests/BlazorLocalTimeTest/Component/LocalTimeTotal1.razor
@@ -2,6 +2,6 @@
 @inject TimeProvider TimeProvider
 
 <p>
-    <LocalTimeText Value="TimeProvider.GetUtcNow()" Format="yyyy-MM-dd HH:mm:ss" />
+    <LocalTimeText Value="TimeProvider.GetUtcNow()" Format="yyyy-MM-dd HH:mm:ss" DisableTimeElement />
 </p>
 <BlazorLocalTimeProvider />

--- a/tests/BlazorLocalTimeTest/LocalTimeTextTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeTextTest.razor
@@ -12,7 +12,7 @@
         );
         
         // 12:30+09:00 -> 2023-10-01 21:30:00
-        cut.MarkupMatches("2023-10-01 21:30:00");
+        cut.MarkupMatches(@"<time datetime=""2023-10-01T12:30:00.0000000Z"">2023-10-01 21:30:00</time>");
     }
     
     [Fact]
@@ -27,7 +27,7 @@
         );
         
         // 12:30+09:00 -> 2023-10-01 21:30:00
-        cut.MarkupMatches("2023-10-01 21:30:00");
+        cut.MarkupMatches(@"<time datetime=""2023-10-01T12:30:00.0000000Z"">2023-10-01 21:30:00</time>");
     }
     
     [Fact]
@@ -41,7 +41,7 @@
         var cut = Render(@<LocalTimeText Value="dt"/>
         );
         
-        cut.MarkupMatches("2023-10-01 12:30:00");
+        cut.MarkupMatches(@"<time datetime=""2023-10-01T03:30:00.0000000Z"">2023-10-01 12:30:00</time>");
     }
     
     [Fact]
@@ -54,7 +54,21 @@
         var cut = Render(@<LocalTimeText Value="dt" Format="yyyy-MM-dd HH:mm"/>
         );
         
-        cut.MarkupMatches("2023-10-01 21:30");
+        cut.MarkupMatches(@"<time datetime=""2023-10-01T12:30:00.0000000Z"">2023-10-01 21:30</time>");
+    }
+    
+    [Fact]
+    public void TestWithoutTimeElement()
+    {
+        Services.AddLocalTimeMockService();
+
+        var dt = new DateTime(2023, 10, 1, 12, 30, 0, DateTimeKind.Utc);
+
+        var cut = Render(@<LocalTimeText Value="dt" DisableTimeElement />
+        );
+        
+        // Should render without time element (default behavior)
+        cut.MarkupMatches("2023-10-01 21:30:00");
     }
     
 }


### PR DESCRIPTION
## Summary
  - Add optional HTML `<time>` element wrapper to LocalTimeText component with proper `datetime` attribute for improved accessibility and semantic HTML
  - Introduce `DisableTimeElement` parameter to maintain backward compatibility
  - Update tests and documentation to reflect new default behavior

  ## Changes
  - **LocalTimeText component**: Now wraps output in `<time datetime="ISO-8601">formatted-time</time>` by default
  - **DisableTimeElement parameter**: Allows users to disable the `<time>` wrapper and get plain text (previous behavior)
  - **ISO-8601 datetime attribute**: Provides machine-readable time format for accessibility tools and browsers
  - **Updated tests**: All component tests now expect the new semantic markup
  - **Enhanced documentation**: Sample app includes usage examples and explanation of the new parameter

  ## Test plan
  - [x] All existing unit tests pass with updated expectations
  - [x] Component renders semantic `<time>` element with proper `datetime` attribute by default
  - [x] `DisableTimeElement=true` produces plain text output (backward compatibility)
  - [x] Sample application demonstrates both usage patterns
  - [x] Public API includes new `DisableTimeElement` parameter