### PR TITLE
Add nullability annotations and simplify time zone logic

### DIFF
--- a/src/BlazorLocalTime/LocalTimeService.cs
+++ b/src/BlazorLocalTime/LocalTimeService.cs
@@ -103,8 +103,8 @@ public interface ILocalTimeService
                 """
                 Failed to obtain the browser's time zone information.
                 Possible causes:
-                1) The `<BrowserLocalTimeProvider />` component has not been added.
-                    In this case, please add `<BrowserLocalTimeProvider />` to a root component such as `Routes.razor`.
+                1) The `<BlazorLocalTimeProvider />` component has not been added.
+                    In this case, please add `<BlazorLocalTimeProvider />` to a root component such as `Routes.razor`.
                 2) You are trying to use `ILocalTimeService` in `OnInitialized(Async)`.
                     In this case, you need to subscribe to the `ILocalTimeService.OnLocalTimeZoneChanged` event
                     and perform processing after the time zone information has been set.

--- a/src/BlazorLocalTime/LocalTimeService.cs
+++ b/src/BlazorLocalTime/LocalTimeService.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorLocalTime;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorLocalTime;
 
 /// <summary>
 /// Provides an interface for a local time service.
@@ -33,6 +35,7 @@ public interface ILocalTimeService
     /// <summary>
     /// Is the local time zone set?
     /// </summary>
+    [MemberNotNullWhen(true, nameof(TimeZoneInfo))]
     public bool IsTimeZoneInfoAvailable => TimeZoneInfo != null;
 
     /// <summary>
@@ -94,7 +97,7 @@ public interface ILocalTimeService
     /// <returns>The <see cref="TimeZoneInfo"/> representing the browser's time zone.</returns>
     public TimeZoneInfo GetBrowserTimeZone()
     {
-        if (TimeZoneInfo == null || !IsTimeZoneInfoAvailable)
+        if (!IsTimeZoneInfoAvailable)
         {
             throw new InvalidOperationException(
                 """

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
@@ -12,6 +12,8 @@ namespace BlazorLocalTime
     public interface ILocalTimeService
     {
         System.TimeZoneInfo? BrowserTimeZoneInfo { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "TimeZoneInfo")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "TimeZoneInfo")]
         bool IsTimeZoneInfoAvailable { get; }
         System.DateTimeOffset Now { get; }
         System.TimeZoneInfo? OverrideTimeZoneInfo { get; set; }

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/arika0093/BlazorLocalTime")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/arika0093/BlazorLocalTime")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BlazorLocalTimeTest")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace BlazorLocalTime
@@ -12,6 +12,8 @@ namespace BlazorLocalTime
     public interface ILocalTimeService
     {
         System.TimeZoneInfo? BrowserTimeZoneInfo { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "TimeZoneInfo")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "TimeZoneInfo")]
         bool IsTimeZoneInfoAvailable { get; }
         System.DateTimeOffset Now { get; }
         System.TimeZoneInfo? OverrideTimeZoneInfo { get; set; }


### PR DESCRIPTION
Introduce nullability annotations for `IsTimeZoneInfoAvailable` and streamline the logic in `GetBrowserTimeZone` to enhance code clarity and safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified internal time zone availability checks to streamline error handling.

- Chores
  - Added null-safety annotations to improve reliability and static analysis.

- Bug Fixes / UX
  - Clarified error text to reference BlazorLocalTimeProvider and suggest registering the provider on a root component, making setup issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->