### PR TITLE
fix: TimeZoneNotFoundException on old windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/BlazorLocalTime.sln
+++ b/BlazorLocalTime.sln
@@ -1,10 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36221.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorLocalTime", "src\BlazorLocalTime\BlazorLocalTime.csproj", "{10BD6EFA-52CE-479D-9086-BACD746F8F36}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorLocalTimeTest", "tests\BlazorLocalTimeTest\BlazorLocalTimeTest.csproj", "{72BC6136-58FA-4856-A568-0D44942DCC5C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorLocalTimeSample", "example\BlazorLocalTimeSample\BlazorLocalTimeSample.csproj", "{4E398EDD-6CFE-44B3-899E-A7325A85CE55}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorLocalTimeTest.Nls", "tests\BlazorLocalTimeTest.Nls\BlazorLocalTimeTest.Nls.csproj", "{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{4F9DEAE5-078F-E77A-2E4A-FEB6FFE226FF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +35,21 @@ Global
 		{4E398EDD-6CFE-44B3-899E-A7325A85CE55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E398EDD-6CFE-44B3-899E-A7325A85CE55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E398EDD-6CFE-44B3-899E-A7325A85CE55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{10BD6EFA-52CE-479D-9086-BACD746F8F36} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{72BC6136-58FA-4856-A568-0D44942DCC5C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{4E398EDD-6CFE-44B3-899E-A7325A85CE55} = {4F9DEAE5-078F-E77A-2E4A-FEB6FFE226FF}
+		{4368AD9B-B26A-4BA5-B5A5-0C1FF66F98BF} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {11F3F046-8555-4A1A-A613-01EDEB5344A3}
 	EndGlobalSection
 EndGlobal

--- a/src/BlazorLocalTime/BlazorLocalTimeConfiguration.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeConfiguration.cs
@@ -10,11 +10,11 @@ public class BlazorLocalTimeConfiguration
     /// </summary>
     public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
-	/// <summary>
-	/// Specifies a function to convert IANA time zones to Windows time zones.
-	/// For example, `TZConvert.IanaToWindows` from TimeZoneConverter(https://github.com/mattjohnsonpint/TimeZoneConverter) can be used.
-	/// This is required on operating systems where ICU is unavailable(such as Windows Server 2016), but need not be specified on others.
-	/// For details, see https://github.com/arika0093/BlazorLocalTime/issues/19
-	/// </summary>
-	public Func<string, string>? IanaToWindows { get; set; } = null;
+    /// <summary>
+    /// Specifies a function to convert IANA time zones to Windows time zones.
+    /// For example, `TZConvert.IanaToWindows` from TimeZoneConverter(https://github.com/mattjohnsonpint/TimeZoneConverter) can be used.
+    /// This is required on operating systems where ICU is unavailable(such as Windows Server 2016), but need not be specified on others.
+    /// For details, see https://github.com/arika0093/BlazorLocalTime/issues/19
+    /// </summary>
+    public Func<string, string>? IanaToWindows { get; set; } = null;
 }

--- a/src/BlazorLocalTime/BlazorLocalTimeConfiguration.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeConfiguration.cs
@@ -1,0 +1,20 @@
+﻿namespace BlazorLocalTime;
+
+/// <summary>
+/// Represents the configuration settings for local time operations in a Blazor application.
+/// </summary>
+public class BlazorLocalTimeConfiguration
+{
+    /// <summary>
+    /// Gets the <see cref="TimeProvider"/> used to supply the current time.
+    /// </summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+	/// <summary>
+	/// Specifies a function to convert IANA time zones to Windows time zones.
+	/// For example, `TZConvert.IanaToWindows` from TimeZoneConverter(https://github.com/mattjohnsonpint/TimeZoneConverter) can be used.
+	/// This is required on operating systems where ICU is unavailable(such as Windows Server 2016), but need not be specified on others.
+	/// For details, see https://github.com/arika0093/BlazorLocalTime/issues/19
+	/// </summary>
+	public Func<string, string>? IanaToWindows { get; set; } = null;
+}

--- a/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
@@ -40,13 +40,13 @@ public static class BlazorLocalTimeExtension
         );
     }
 
-	/// <summary>
-	/// Adds the BlazorLocalTime service to the service collection with configurable option.
-	/// </summary>
-	/// <param name="services">The service collection.</param>
-	/// <param name="configuration">An action to configure BlazorLocalTime options.</param>
-	/// <returns>The updated service collection.</returns>
-	public static IServiceCollection AddBlazorLocalTimeService(
+    /// <summary>
+    /// Adds the BlazorLocalTime service to the service collection with configurable option.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">An action to configure BlazorLocalTime options.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlazorLocalTimeService(
         this IServiceCollection services,
         Action<BlazorLocalTimeConfiguration> configuration
     )

--- a/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
@@ -52,11 +52,12 @@ public static class BlazorLocalTimeExtension
     )
     {
         services.AddScoped<ILocalTimeService, LocalTimeService>();
-        services.AddSingleton<BlazorLocalTimeConfiguration>(_ => {
+        services.AddSingleton<BlazorLocalTimeConfiguration>(_ =>
+        {
             var config = new BlazorLocalTimeConfiguration();
             configuration(config);
             return config;
-		});
-		return services;
+        });
+        return services;
     }
 }

--- a/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
@@ -31,8 +31,32 @@ public static class BlazorLocalTimeExtension
         TimeProvider timeProvider
     )
     {
+        return AddBlazorLocalTimeService(
+            services,
+            option =>
+            {
+                option.TimeProvider = timeProvider;
+            }
+        );
+    }
+
+    /// <summary>
+    /// Adds the BlazorLocalTime service to the service collection with a custom time provider.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The time provider to use for local time calculations.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlazorLocalTimeService(
+        this IServiceCollection services,
+        Action<BlazorLocalTimeConfiguration> configuration
+    )
+    {
         services.AddScoped<ILocalTimeService, LocalTimeService>();
-        services.TryAddSingleton<TimeProvider>(timeProvider);
-        return services;
+        services.AddSingleton<BlazorLocalTimeConfiguration>(_ => {
+            var config = new BlazorLocalTimeConfiguration();
+            configuration(config);
+            return config;
+		});
+		return services;
     }
 }

--- a/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
+++ b/src/BlazorLocalTime/BlazorLocalTimeExtension.cs
@@ -40,13 +40,13 @@ public static class BlazorLocalTimeExtension
         );
     }
 
-    /// <summary>
-    /// Adds the BlazorLocalTime service to the service collection with a custom time provider.
-    /// </summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="configuration">The time provider to use for local time calculations.</param>
-    /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddBlazorLocalTimeService(
+	/// <summary>
+	/// Adds the BlazorLocalTime service to the service collection with configurable option.
+	/// </summary>
+	/// <param name="services">The service collection.</param>
+	/// <param name="configuration">An action to configure BlazorLocalTime options.</param>
+	/// <returns>The updated service collection.</returns>
+	public static IServiceCollection AddBlazorLocalTimeService(
         this IServiceCollection services,
         Action<BlazorLocalTimeConfiguration> configuration
     )

--- a/src/BlazorLocalTime/Components/BlazorLocalTimeProvider.razor.cs
+++ b/src/BlazorLocalTime/Components/BlazorLocalTimeProvider.razor.cs
@@ -38,7 +38,7 @@ public sealed partial class BlazorLocalTimeProvider : ComponentBase
                     JsPath
                 );
                 var timeZoneString = await module.InvokeAsync<string>("getBrowserTimeZone");
-                if (!ICUMode())
+                if (!IsIcuEnabled())
                 {
                     // On Windows with NLS mode, IANA time zone are must be converted to Windows time zone.
                     var converter = Configuration.IanaToWindows;
@@ -79,7 +79,7 @@ public sealed partial class BlazorLocalTimeProvider : ComponentBase
     }
 
     // https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
-    private static bool ICUMode()
+    private static bool IsIcuEnabled()
     {
         SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
         byte[] bytes = sortVersion.SortId.ToByteArray();

--- a/src/BlazorLocalTime/Components/BlazorLocalTimeProvider.razor.cs
+++ b/src/BlazorLocalTime/Components/BlazorLocalTimeProvider.razor.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
-using System.Globalization;
 
 namespace BlazorLocalTime;
 
@@ -22,11 +22,11 @@ public sealed partial class BlazorLocalTimeProvider : ComponentBase
     [Inject]
     private ILogger<BlazorLocalTimeProvider> Logger { get; set; } = null!;
 
-	[Inject]
-	private BlazorLocalTimeConfiguration Configuration { get; set; } = null!;
+    [Inject]
+    private BlazorLocalTimeConfiguration Configuration { get; set; } = null!;
 
-	/// <inheritdoc />
-	protected override async Task OnAfterRenderAsync(bool firstRender)
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender && !LocalTimeService.IsTimeZoneInfoAvailable)
         {
@@ -38,19 +38,21 @@ public sealed partial class BlazorLocalTimeProvider : ComponentBase
                     JsPath
                 );
                 var timeZoneString = await module.InvokeAsync<string>("getBrowserTimeZone");
-                if(!ICUMode()) {
-					// On Windows with NLS mode, IANA time zone are must be converted to Windows time zone.
-					var converter = Configuration.IanaToWindows;
-                    if(converter == null) {
+                if (!ICUMode())
+                {
+                    // On Windows with NLS mode, IANA time zone are must be converted to Windows time zone.
+                    var converter = Configuration.IanaToWindows;
+                    if (converter == null)
+                    {
                         var message = """
-                        In older Windows environments, IANA time zones (such as “Asia/Tokyo”) cannot be used directly.
-                        For details, see https://github.com/arika0093/BlazorLocalTime/issues/19.
-                        """;
+                            In older Windows environments, IANA time zones (such as “Asia/Tokyo”) cannot be used directly.
+                            For details, see https://github.com/arika0093/BlazorLocalTime/issues/19.
+                            """;
                         throw new TimeZoneNotFoundException(message);
-					}
+                    }
                     timeZoneString = converter(timeZoneString);
-				}
-				timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneString);
+                }
+                timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneString);
             }
             catch (JSDisconnectedException ex)
             {
@@ -76,12 +78,12 @@ public sealed partial class BlazorLocalTimeProvider : ComponentBase
         }
     }
 
-	// https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
-	private static bool ICUMode()
-	{
-		SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
-		byte[] bytes = sortVersion.SortId.ToByteArray();
-		int version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
-		return version != 0 && version == sortVersion.FullVersion;
-	}
+    // https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
+    private static bool ICUMode()
+    {
+        SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
+        byte[] bytes = sortVersion.SortId.ToByteArray();
+        int version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+        return version != 0 && version == sortVersion.FullVersion;
+    }
 }

--- a/src/BlazorLocalTime/ILocalTimeService.cs
+++ b/src/BlazorLocalTime/ILocalTimeService.cs
@@ -1,0 +1,116 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorLocalTime;
+
+/// <summary>
+/// Provides an interface for a local time service.
+/// </summary>
+public interface ILocalTimeService
+{
+    /// <summary>
+    /// Browser's time zone information. if you want to override it, set <see cref="OverrideTimeZoneInfo"/>.
+    /// </summary>
+    TimeZoneInfo? TimeZoneInfo { get; }
+
+    /// <summary>
+    /// Browser's original time zone information (read-only).
+    /// </summary>
+    TimeZoneInfo? BrowserTimeZoneInfo { get; }
+
+    /// <summary>
+    /// User-specified override time zone information. If you want to reset it, set this property to null.
+    /// </summary>
+    TimeZoneInfo? OverrideTimeZoneInfo { get; set; }
+
+    /// <summary>
+    /// Gets the current browser's local time as a <see cref="DateTimeOffset"/>.
+    /// </summary>
+    DateTimeOffset Now { get; }
+
+    /// <summary>
+    /// On local time zone changed event with detailed timezone information.
+    /// </summary>
+    event EventHandler<TimeZoneChangedEventArgs> LocalTimeZoneChanged;
+
+    /// <summary>
+    /// Is the local time zone set?
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(TimeZoneInfo))]
+    public bool IsTimeZoneInfoAvailable => TimeZoneInfo != null;
+
+    /// <summary>
+    /// Is the browser's time zone information successfully loaded?
+    /// This property is set to null until the browser's time zone information is loaded.
+    /// If the browser's time zone information is successfully loaded, it will be set to true.
+    /// </summary>
+    internal bool? IsSuccessLoadBrowserTimeZone { get; set; }
+
+    /// <summary>
+    /// Sets the browser's time zone information.
+    /// this method is only for internal use.
+    /// </summary>
+    internal void SetBrowserTimeZoneInfo(TimeZoneInfo? timeZoneInfo);
+
+    /// <summary>
+    /// Converts the specified UTC <see cref="DateTime"/> to local time.
+    /// </summary>
+    /// <param name="utcDateTime">The UTC date and time to convert.</param>
+    /// <returns>The local <see cref="DateTime"/>.</returns>
+    public DateTime ToLocalTime(DateTime utcDateTime)
+    {
+        return TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, GetBrowserTimeZone());
+    }
+
+    /// <summary>
+    /// Converts the <see cref="DateTimeOffset"/> to local time as a <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="dateTimeOffset"> The UTC date and time offset to convert.</param>
+    /// <returns>The local <see cref="DateTime"/>.</returns>
+    public DateTime ToLocalTime(DateTimeOffset dateTimeOffset)
+    {
+        return ToLocalTime(dateTimeOffset.UtcDateTime);
+    }
+
+    /// <summary>
+    /// Converts the specified UTC <see cref="DateTime"/> to a local <see cref="DateTimeOffset"/>.
+    /// </summary>
+    /// <param name="utcDateTime">The UTC date and time to convert.</param>
+    /// <returns>The local <see cref="DateTimeOffset"/>.</returns>
+    public DateTimeOffset ToLocalTimeOffset(DateTime utcDateTime)
+    {
+        return new(ToLocalTime(utcDateTime), GetBrowserTimeZone().GetUtcOffset(utcDateTime));
+    }
+
+    /// <summary>
+    /// Converts the <see cref="DateTimeOffset"/> to a local <see cref="DateTimeOffset"/>.
+    /// </summary>
+    /// <param name="dateTimeOffset">The UTC date and time to convert.</param>
+    /// <returns>The local <see cref="DateTimeOffset"/>.</returns>
+    public DateTimeOffset ToLocalTimeOffset(DateTimeOffset dateTimeOffset)
+    {
+        return new(ToLocalTime(dateTimeOffset), GetBrowserTimeZone().GetUtcOffset(dateTimeOffset));
+    }
+
+    /// <summary>
+    /// Gets the browser's time zone information.
+    /// </summary>
+    /// <returns>The <see cref="TimeZoneInfo"/> representing the browser's time zone.</returns>
+    public TimeZoneInfo GetBrowserTimeZone()
+    {
+        if (!IsTimeZoneInfoAvailable)
+        {
+            throw new InvalidOperationException(
+                """
+                Failed to obtain the browser's time zone information.
+                Possible causes:
+                1) The `<BlazorLocalTimeProvider />` component has not been added.
+                    In this case, please add `<BlazorLocalTimeProvider />` to a root component such as `Routes.razor`.
+                2) You are trying to use `ILocalTimeService` in `OnInitialized(Async)`.
+                    In this case, you need to subscribe to the `ILocalTimeService.OnLocalTimeZoneChanged` event
+                    and perform processing after the time zone information has been set.
+                """
+            );
+        }
+        return TimeZoneInfo;
+    }
+}

--- a/src/BlazorLocalTime/LocalTimeService.cs
+++ b/src/BlazorLocalTime/LocalTimeService.cs
@@ -3,122 +3,9 @@
 namespace BlazorLocalTime;
 
 /// <summary>
-/// Provides an interface for a local time service.
-/// </summary>
-public interface ILocalTimeService
-{
-    /// <summary>
-    /// Browser's time zone information. if you want to override it, set <see cref="OverrideTimeZoneInfo"/>.
-    /// </summary>
-    TimeZoneInfo? TimeZoneInfo { get; }
-
-    /// <summary>
-    /// Browser's original time zone information (read-only).
-    /// </summary>
-    TimeZoneInfo? BrowserTimeZoneInfo { get; }
-
-    /// <summary>
-    /// User-specified override time zone information. If you want to reset it, set this property to null.
-    /// </summary>
-    TimeZoneInfo? OverrideTimeZoneInfo { get; set; }
-
-    /// <summary>
-    /// Gets the current browser's local time as a <see cref="DateTimeOffset"/>.
-    /// </summary>
-    DateTimeOffset Now { get; }
-
-    /// <summary>
-    /// On local time zone changed event with detailed timezone information.
-    /// </summary>
-    event EventHandler<TimeZoneChangedEventArgs> LocalTimeZoneChanged;
-
-    /// <summary>
-    /// Is the local time zone set?
-    /// </summary>
-    [MemberNotNullWhen(true, nameof(TimeZoneInfo))]
-    public bool IsTimeZoneInfoAvailable => TimeZoneInfo != null;
-
-    /// <summary>
-    /// Is the browser's time zone information successfully loaded?
-    /// This property is set to null until the browser's time zone information is loaded.
-    /// If the browser's time zone information is successfully loaded, it will be set to true.
-    /// </summary>
-    internal bool? IsSuccessLoadBrowserTimeZone { get; set; }
-
-    /// <summary>
-    /// Sets the browser's time zone information.
-    /// this method is only for internal use.
-    /// </summary>
-    internal void SetBrowserTimeZoneInfo(TimeZoneInfo? timeZoneInfo);
-
-    /// <summary>
-    /// Converts the specified UTC <see cref="DateTime"/> to local time.
-    /// </summary>
-    /// <param name="utcDateTime">The UTC date and time to convert.</param>
-    /// <returns>The local <see cref="DateTime"/>.</returns>
-    public DateTime ToLocalTime(DateTime utcDateTime)
-    {
-        return TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, GetBrowserTimeZone());
-    }
-
-    /// <summary>
-    /// Converts the <see cref="DateTimeOffset"/> to local time as a <see cref="DateTime"/>.
-    /// </summary>
-    /// <param name="dateTimeOffset"> The UTC date and time offset to convert.</param>
-    /// <returns>The local <see cref="DateTime"/>.</returns>
-    public DateTime ToLocalTime(DateTimeOffset dateTimeOffset)
-    {
-        return ToLocalTime(dateTimeOffset.UtcDateTime);
-    }
-
-    /// <summary>
-    /// Converts the specified UTC <see cref="DateTime"/> to a local <see cref="DateTimeOffset"/>.
-    /// </summary>
-    /// <param name="utcDateTime">The UTC date and time to convert.</param>
-    /// <returns>The local <see cref="DateTimeOffset"/>.</returns>
-    public DateTimeOffset ToLocalTimeOffset(DateTime utcDateTime)
-    {
-        return new(ToLocalTime(utcDateTime), GetBrowserTimeZone().GetUtcOffset(utcDateTime));
-    }
-
-    /// <summary>
-    /// Converts the <see cref="DateTimeOffset"/> to a local <see cref="DateTimeOffset"/>.
-    /// </summary>
-    /// <param name="dateTimeOffset">The UTC date and time to convert.</param>
-    /// <returns>The local <see cref="DateTimeOffset"/>.</returns>
-    public DateTimeOffset ToLocalTimeOffset(DateTimeOffset dateTimeOffset)
-    {
-        return new(ToLocalTime(dateTimeOffset), GetBrowserTimeZone().GetUtcOffset(dateTimeOffset));
-    }
-
-    /// <summary>
-    /// Gets the browser's time zone information.
-    /// </summary>
-    /// <returns>The <see cref="TimeZoneInfo"/> representing the browser's time zone.</returns>
-    public TimeZoneInfo GetBrowserTimeZone()
-    {
-        if (!IsTimeZoneInfoAvailable)
-        {
-            throw new InvalidOperationException(
-                """
-                Failed to obtain the browser's time zone information.
-                Possible causes:
-                1) The `<BlazorLocalTimeProvider />` component has not been added.
-                    In this case, please add `<BlazorLocalTimeProvider />` to a root component such as `Routes.razor`.
-                2) You are trying to use `ILocalTimeService` in `OnInitialized(Async)`.
-                    In this case, you need to subscribe to the `ILocalTimeService.OnLocalTimeZoneChanged` event
-                    and perform processing after the time zone information has been set.
-                """
-            );
-        }
-        return TimeZoneInfo;
-    }
-}
-
-/// <summary>
 /// Provides methods for converting UTC time to local time and retrieving browser time zone information.
 /// </summary>
-internal class LocalTimeService(TimeProvider timeProvider) : ILocalTimeService
+internal class LocalTimeService(BlazorLocalTimeConfiguration configuration) : ILocalTimeService
 {
     private TimeZoneInfo? _overrideTimeZoneInfo;
 
@@ -156,7 +43,7 @@ internal class LocalTimeService(TimeProvider timeProvider) : ILocalTimeService
 
     /// <inheritdoc />
     public DateTimeOffset Now =>
-        ((ILocalTimeService)this).ToLocalTimeOffset(timeProvider.GetUtcNow());
+        ((ILocalTimeService)this).ToLocalTimeOffset(configuration.TimeProvider.GetUtcNow());
 
     /// <inheritdoc />
     public bool? IsSuccessLoadBrowserTimeZone { get; set; } = null;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,6 +36,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>BlazorLocalTimeTest</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>BlazorLocalTimeTest.Nls</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />

--- a/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
+++ b/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
@@ -1,0 +1,38 @@
+﻿@inherits TestContext
+@code
+{
+    // try NLS timezone detection
+    // https://github.com/arika0093/BlazorLocalTime/issues/19
+    [Fact]
+    public void TestLocalTimeProviderInNls()
+    {
+        Services.AddBlazorLocalTimeService();
+        TestInitializer.JavaScriptInitializer(JSInterop);
+
+        Should.Throw<System.TimeZoneNotFoundException>(() =>
+        {
+            // cannot convert timezone from IANA to Windows
+            Render(
+                @<BlazorLocalTimeProvider />
+            );
+        });
+    }
+
+    // try NLS timezone detection with converter
+    [Fact]
+    public void TestLocalTimeProviderInNlsWithConverter()
+    {
+        Services.AddBlazorLocalTimeService(options =>
+        {
+            options.IanaToWindows = TimeZoneConverter.TZConvert.IanaToWindows;
+        });
+        TestInitializer.JavaScriptInitializer(JSInterop);
+
+        // can convertable
+        Render(
+            @<BlazorLocalTimeProvider />
+        );
+    }
+
+}
+

--- a/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
+++ b/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
@@ -40,7 +40,6 @@
         );
     }
 
-
     private bool IsWindows() => OperatingSystem.IsWindows();
 }
 

--- a/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
+++ b/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeProviderTest.razor
@@ -3,9 +3,12 @@
 {
     // try NLS timezone detection
     // https://github.com/arika0093/BlazorLocalTime/issues/19
-    [Fact]
+    [SkippableFact]
     public void TestLocalTimeProviderInNls()
     {
+        // only windows
+        Skip.IfNot(IsWindows(), $"Only Windows OS can run this test.");
+
         Services.AddBlazorLocalTimeService();
         TestInitializer.JavaScriptInitializer(JSInterop);
 
@@ -19,9 +22,12 @@
     }
 
     // try NLS timezone detection with converter
-    [Fact]
+    [SkippableFact]
     public void TestLocalTimeProviderInNlsWithConverter()
     {
+        // only windows
+        Skip.IfNot(IsWindows(), $"Only Windows OS can run this test.");
+
         Services.AddBlazorLocalTimeService(options =>
         {
             options.IanaToWindows = TimeZoneConverter.TZConvert.IanaToWindows;
@@ -34,5 +40,7 @@
         );
     }
 
+
+    private bool IsWindows() => OperatingSystem.IsWindows();
 }
 

--- a/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeTest.Nls.csproj
+++ b/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeTest.Nls.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TimeZoneConverter" Version="7.0.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />

--- a/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeTest.Nls.csproj
+++ b/tests/BlazorLocalTimeTest.Nls/BlazorLocalTimeTest.Nls.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TimeZoneConverter" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlazorLocalTime\BlazorLocalTime.csproj" />
+    <ProjectReference Include="..\BlazorLocalTimeTest\BlazorLocalTimeTest.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/BlazorLocalTimeTest.Nls/_Imports.razor
+++ b/tests/BlazorLocalTimeTest.Nls/_Imports.razor
@@ -1,0 +1,8 @@
+﻿@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using Microsoft.Extensions.DependencyInjection
+@using AngleSharp.Dom
+@using Bunit
+@using Bunit.TestDoubles
+@using BlazorLocalTime

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net8.approved.txt
@@ -1,8 +1,15 @@
 ﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/arika0093/BlazorLocalTime")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BlazorLocalTimeTest")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BlazorLocalTimeTest.Nls")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace BlazorLocalTime
 {
+    public class BlazorLocalTimeConfiguration
+    {
+        public BlazorLocalTimeConfiguration() { }
+        public System.Func<string, string>? IanaToWindows { get; set; }
+        public System.TimeProvider TimeProvider { get; set; }
+    }
     public sealed class BlazorLocalTimeProvider : Microsoft.AspNetCore.Components.ComponentBase
     {
         public BlazorLocalTimeProvider() { }

--- a/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
+++ b/tests/BlazorLocalTimeTest/Approvals/PublicApiCheckTest.Run.net9.approved.txt
@@ -1,8 +1,15 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/arika0093/BlazorLocalTime")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BlazorLocalTimeTest")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("BlazorLocalTimeTest.Nls")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace BlazorLocalTime
 {
+    public class BlazorLocalTimeConfiguration
+    {
+        public BlazorLocalTimeConfiguration() { }
+        public System.Func<string, string>? IanaToWindows { get; set; }
+        public System.TimeProvider TimeProvider { get; set; }
+    }
     public sealed class BlazorLocalTimeProvider : Microsoft.AspNetCore.Components.ComponentBase
     {
         public BlazorLocalTimeProvider() { }

--- a/tests/BlazorLocalTimeTest/BlazorLocalTimeProviderTest.razor
+++ b/tests/BlazorLocalTimeTest/BlazorLocalTimeProviderTest.razor
@@ -5,12 +5,8 @@
     [Fact]
     public void TestLocalTimeProvider()
     {
-        var tms = new LocalTimeMockService(TimeProvider.System)
-        {
-            BrowserTimeZoneInfo = null
-        };
-        
-        Services.AddScoped<ILocalTimeService, LocalTimeMockService>(_ => tms);
+        var tms = new LocalTimeEmptyMockService(new() { TimeProvider = TimeProvider.System });
+        Services.AddLocalTimeMockService(tms);
         TestInitializer.JavaScriptInitializer(JSInterop);
 
         Render(

--- a/tests/BlazorLocalTimeTest/BlazorLocalTimeTest.csproj
+++ b/tests/BlazorLocalTimeTest/BlazorLocalTimeTest.csproj
@@ -6,11 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.40.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
-  </ItemGroup>
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlazorLocalTime\BlazorLocalTime.csproj" />

--- a/tests/BlazorLocalTimeTest/LocalTimeChangeEventTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeChangeEventTest.razor
@@ -3,17 +3,15 @@
 @inherits TestContext
 @code
 {
+
     [Fact]
     public void TestCustomFormat1()
     {
-        var tms = new LocalTimeMockService(TimeProvider.System)
-        {
-            BrowserTimeZoneInfo = null
-        };
+        var tms = new LocalTimeEmptyMockService(new());
         var tokyo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
         var utc = TimeZoneInfo.FindSystemTimeZoneById("UTC");
         
-        Services.AddScoped<ILocalTimeService, LocalTimeMockService>(_ => tms);
+        Services.AddLocalTimeMockService(tms);
         TestInitializer.JavaScriptInitializer(JSInterop);
 
         var cut = RenderComponent<LocalTimeChangeEvent>();

--- a/tests/BlazorLocalTimeTest/LocalTimeFormDefaultTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeFormDefaultTest.razor
@@ -9,8 +9,7 @@
     {
         // add a mock time provider to control the current time
         var mockTimeProvider = new MockTimeProvider(new(2020, 1, 1, 12, 34, 56, TimeSpan.Zero));
-        Services.AddScoped<ILocalTimeService, LocalTimeMockService>(); // Asia/Tokyo (UTC+9)
-        Services.TryAddSingleton<TimeProvider>(mockTimeProvider);
+        Services.AddLocalTimeMockService(mockTimeProvider);
 
         DateTime? dt = null;
         var cut = RenderComponent<LocalTimeFormWithDefault>(parameters =>

--- a/tests/BlazorLocalTimeTest/LocalTimeFormTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeFormTest.razor
@@ -94,8 +94,8 @@
     public void TestFormOnlyDateUpdate()
     {
         // add a mock time provider to control the current time
-        Services.AddSingleton<TimeProvider>(_ => new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero)));
-        Services.AddLocalTimeMockService();
+        var mockTimeProvider = new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero));
+        Services.AddLocalTimeMockService(mockTimeProvider);
 
         DateTime? dt = null;
         
@@ -117,8 +117,8 @@
     public void TestFormOnlyTimeUpdate()
     {
         // add a mock time provider to control the current time
-        Services.AddSingleton<TimeProvider>(_ => new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero)));
-        Services.AddLocalTimeMockService();
+        var mockTimeProvider = new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero));
+        Services.AddLocalTimeMockService(mockTimeProvider);
 
         DateTimeOffset? dt = null;
         

--- a/tests/BlazorLocalTimeTest/LocalTimeMockService.cs
+++ b/tests/BlazorLocalTimeTest/LocalTimeMockService.cs
@@ -6,18 +6,21 @@ namespace BlazorLocalTimeTest;
 
 internal class LocalTimeMockService : LocalTimeService
 {
-    public LocalTimeMockService(TimeProvider provider)
-        : base(provider)
+    internal BlazorLocalTimeConfiguration Config;
+
+	public LocalTimeMockService(BlazorLocalTimeConfiguration config)
+        : base(config)
     {
-        // Mocking the browser's time zone to Asia/Tokyo for testing purposes.
-        BrowserTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        Config = config;
+		// Mocking the browser's time zone to Asia/Tokyo for testing purposes.
+		BrowserTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
     }
 }
 
-internal class LocalTimeEmptyMockService : LocalTimeService
+internal class LocalTimeEmptyMockService : LocalTimeMockService
 {
-    public LocalTimeEmptyMockService(TimeProvider provider)
-        : base(provider)
+    public LocalTimeEmptyMockService(BlazorLocalTimeConfiguration config)
+        : base(config)
     {
         BrowserTimeZoneInfo = null;
     }
@@ -28,7 +31,25 @@ internal static class LocalTimeMockServiceExtension
     public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services)
     {
         services.AddScoped<ILocalTimeService, LocalTimeMockService>();
-        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+        services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => new() {
+			TimeProvider = TimeProvider.System
+		});
         return services;
     }
+	
+    public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services, LocalTimeMockService instance)
+	{
+		services.AddScoped<ILocalTimeService>(_ => instance);
+		services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => instance.Config);
+		return services;
+	}
+
+	public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services, MockTimeProvider instance)
+	{
+		services.AddScoped<ILocalTimeService, LocalTimeMockService>();
+		services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => new() {
+			TimeProvider = instance
+		});
+		return services;
+	}
 }

--- a/tests/BlazorLocalTimeTest/LocalTimeMockService.cs
+++ b/tests/BlazorLocalTimeTest/LocalTimeMockService.cs
@@ -8,12 +8,12 @@ internal class LocalTimeMockService : LocalTimeService
 {
     internal BlazorLocalTimeConfiguration Config;
 
-	public LocalTimeMockService(BlazorLocalTimeConfiguration config)
+    public LocalTimeMockService(BlazorLocalTimeConfiguration config)
         : base(config)
     {
         Config = config;
-		// Mocking the browser's time zone to Asia/Tokyo for testing purposes.
-		BrowserTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        // Mocking the browser's time zone to Asia/Tokyo for testing purposes.
+        BrowserTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
     }
 }
 
@@ -31,25 +31,31 @@ internal static class LocalTimeMockServiceExtension
     public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services)
     {
         services.AddScoped<ILocalTimeService, LocalTimeMockService>();
-        services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => new() {
-			TimeProvider = TimeProvider.System
-		});
+        services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ =>
+            new() { TimeProvider = TimeProvider.System }
+        );
         return services;
     }
-	
-    public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services, LocalTimeMockService instance)
-	{
-		services.AddScoped<ILocalTimeService>(_ => instance);
-		services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => instance.Config);
-		return services;
-	}
 
-	public static IServiceCollection AddLocalTimeMockService(this IServiceCollection services, MockTimeProvider instance)
-	{
-		services.AddScoped<ILocalTimeService, LocalTimeMockService>();
-		services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => new() {
-			TimeProvider = instance
-		});
-		return services;
-	}
+    public static IServiceCollection AddLocalTimeMockService(
+        this IServiceCollection services,
+        LocalTimeMockService instance
+    )
+    {
+        services.AddScoped<ILocalTimeService>(_ => instance);
+        services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ => instance.Config);
+        return services;
+    }
+
+    public static IServiceCollection AddLocalTimeMockService(
+        this IServiceCollection services,
+        MockTimeProvider instance
+    )
+    {
+        services.AddScoped<ILocalTimeService, LocalTimeMockService>();
+        services.TryAddSingleton<BlazorLocalTimeConfiguration>(_ =>
+            new() { TimeProvider = instance }
+        );
+        return services;
+    }
 }

--- a/tests/BlazorLocalTimeTest/LocalTimeServiceTest.cs
+++ b/tests/BlazorLocalTimeTest/LocalTimeServiceTest.cs
@@ -8,8 +8,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_InitialState_IsSuccessLoadBrowserTimeZoneIsNull()
     {
-        var service = new LocalTimeService(TimeProvider.System);
-
+        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
         service.IsSuccessLoadBrowserTimeZone.ShouldBeNull();
         ((ILocalTimeService)service).IsTimeZoneInfoAvailable.ShouldBeFalse();
     }
@@ -17,7 +16,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_SetBrowserTimeZoneInfo_SetsSuccessFlag()
     {
-        var service = new LocalTimeService(TimeProvider.System);
+        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
         var timeZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
 
         service.SetBrowserTimeZoneInfo(timeZone);
@@ -29,7 +28,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_TimeZoneConversion_WorksWithSetTimeZone()
     {
-        var service = new LocalTimeService(TimeProvider.System);
+        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
         var utcTime = new DateTimeOffset(2023, 12, 25, 10, 0, 0, TimeSpan.Zero);
         var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
 

--- a/tests/BlazorLocalTimeTest/LocalTimeServiceTest.cs
+++ b/tests/BlazorLocalTimeTest/LocalTimeServiceTest.cs
@@ -8,7 +8,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_InitialState_IsSuccessLoadBrowserTimeZoneIsNull()
     {
-        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
+        var service = new LocalTimeService(new() { TimeProvider = TimeProvider.System });
         service.IsSuccessLoadBrowserTimeZone.ShouldBeNull();
         ((ILocalTimeService)service).IsTimeZoneInfoAvailable.ShouldBeFalse();
     }
@@ -16,7 +16,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_SetBrowserTimeZoneInfo_SetsSuccessFlag()
     {
-        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
+        var service = new LocalTimeService(new() { TimeProvider = TimeProvider.System });
         var timeZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
 
         service.SetBrowserTimeZoneInfo(timeZone);
@@ -28,7 +28,7 @@ public class LocalTimeServiceTest
     [Fact]
     public void LocalTimeService_TimeZoneConversion_WorksWithSetTimeZone()
     {
-        var service = new LocalTimeService(new(){ TimeProvider = TimeProvider.System });
+        var service = new LocalTimeService(new() { TimeProvider = TimeProvider.System });
         var utcTime = new DateTimeOffset(2023, 12, 25, 10, 0, 0, TimeSpan.Zero);
         var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
 

--- a/tests/BlazorLocalTimeTest/LocalTimeTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeTest.razor
@@ -72,8 +72,8 @@
     [Fact]
     public void TestLoadingComponent1()
     {
-        Services.AddScoped<ILocalTimeService, LocalTimeEmptyMockService>();
-        Services.AddSingleton<TimeProvider>(TimeProvider.System);
+        var tms = new LocalTimeEmptyMockService(new() { TimeProvider = TimeProvider.System });
+        Services.AddLocalTimeMockService(tms);
 
         var dt = new DateTime(2023, 10, 1, 12, 30, 0, DateTimeKind.Utc);
 

--- a/tests/BlazorLocalTimeTest/LocalTimeTotalTest.razor
+++ b/tests/BlazorLocalTimeTest/LocalTimeTotalTest.razor
@@ -6,7 +6,8 @@
     public void TestTotal1()
     {
         var timeProvider = new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero));
-        Services.AddBlazorLocalTimeService(timeProvider);
+        Services.AddBlazorLocalTimeService(option => option.TimeProvider = timeProvider);
+        Services.AddSingleton<TimeProvider>(timeProvider);
         TestInitializer.JavaScriptInitializer(JSInterop);
 
         var cut = RenderComponent<LocalTimeTotal1>();
@@ -18,6 +19,7 @@
     public void TestTotalFailed1()
     {
         Services.AddBlazorLocalTimeService();
+        Services.AddSingleton<TimeProvider>(TimeProvider.System);
         TestInitializer.JavaScriptInitializer(JSInterop);
 
         Should.Throw<InvalidOperationException>(() =>
@@ -31,7 +33,8 @@
     public void TestTotal2Success()
     {
         var timeProvider = new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero));
-        Services.AddBlazorLocalTimeService(timeProvider);
+        Services.AddBlazorLocalTimeService(option => option.TimeProvider = timeProvider);
+        Services.AddSingleton<TimeProvider>(timeProvider);
         TestInitializer.JavaScriptInitializer(JSInterop);
 
         var cut = RenderComponent<LocalTimeTotal2>();
@@ -43,7 +46,8 @@
     public void TestTotal2Error()
     {
         var timeProvider = new MockTimeProvider(new(2023, 10, 1, 12, 34, 56, TimeSpan.Zero));
-        Services.AddBlazorLocalTimeService(timeProvider);
+        Services.AddBlazorLocalTimeService(option => option.TimeProvider = timeProvider);
+        Services.AddSingleton<TimeProvider>(timeProvider);
         var module = JSInterop.SetupModule(BlazorLocalTimeProvider.JsPath);
         module.Setup<string>("getBrowserTimeZone").SetException(new JSException("error"));
 

--- a/tests/BlazorLocalTimeTest/TestInitializer.cs
+++ b/tests/BlazorLocalTimeTest/TestInitializer.cs
@@ -17,7 +17,7 @@ public static class TestInitializer
         TimeZoneInfo.Local.BaseUtcOffset.ShouldBe(TimeSpan.Zero);
     }
 
-    internal static void JavaScriptInitializer(BunitJSInterop jsInterop)
+    public static void JavaScriptInitializer(BunitJSInterop jsInterop)
     {
         var module = jsInterop.SetupModule(BlazorLocalTimeProvider.JsPath);
         module.Setup<string>("getBrowserTimeZone").SetResult("Asia/Tokyo");

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,10 +8,15 @@
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="4.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="bunit" Version="1.40.0" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces support for environments where ICU (International Components for Unicode) is unavailable, such as Windows Server 2016, by allowing conversion from IANA to Windows time zones through a configurable converter. It also refactors service registration to use a new configuration class, improves dependency injection, and adds targeted tests for NLS mode. The changes enhance flexibility and reliability of time zone detection and conversion in Blazor applications.

close #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable options: selectable TimeProvider and optional IANA→Windows converter; new service registration overload to configure options.
  * Improved browser time-zone resolution with ICU/NLS detection and clearer guidance when conversion is required.

* **Tests**
  * Added NLS-focused tests and updated test utilities to exercise converter and platform behaviors.

* **Chores**
  * Updated solution/project layout and CI/test matrix; expanded test build configuration and internal visibility for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->